### PR TITLE
Adding Stremio Addon Manager plugin to registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -71,6 +71,14 @@
       "version": "1.0.0",
       "repo": "https://github.com/Fxy6969/Stremio-Glass-Theme",
       "download": "https://github.com/Fxy6969/Stremio-Glass-Theme/releases/download/2.0/horizontal-navigation.plugin.js"
+    },    
+    {
+      "name": "Stremio Addon Manager",
+      "author": "Zcc09",
+      "description": "Reorganize and rename your Stremio addons from the client.",
+      "version": "1.8.1",
+      "repo": "https://github.com/Zcc09/stremio-addon-manager-plugin",
+      "download": "https://github.com/Zcc09/stremio-addon-manager-plugin/releases/download/Release/stremio-addon-manager.plugin.js"
     }
   ],
   "themes": [


### PR DESCRIPTION
A plugin implementation of the Stremio Addon Manager that allows the user to edit, re-organize, and delete non-protected Stremio Addons from within the Stremio Enhanced Client.