### PR TITLE
Add TheIntroDB plugin to registry.json

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -9,6 +9,15 @@
         "download": "https://raw.githubusercontent.com/REVENGE977/stremio-aniskip/refs/heads/main/dist/AniSkip.plugin.js"
       },
       {
+        "name": "TheIntroDB",
+        "author": "TheIntroDB",
+        "description": "Skip intros, recaps, credits, and previews in TV shows and movies in Stremio Enhanced using TheIntroDB API",
+        "version": "0.1.1",
+        "repo": "https://github.com/TheIntroDB/stremio-enhanced-plugin",
+        "preview": "https://theintrodb.org/thumbnail.png",
+        "download": "https://github.com/TheIntroDB/stremio-enhanced-plugin/releases/download/v0.1.1/tidb.plugin.js"
+      },
+      {
         "name": "Stremio Addon Manager",
         "author": "Sul-404",
         "description": "Enhanced UI for managing, reordering, and backing up addons.",

--- a/registry.json
+++ b/registry.json
@@ -15,7 +15,7 @@
         "version": "0.1.2",
         "repo": "https://github.com/TheIntroDB/stremio-enhanced-plugin",
         "preview": "https://theintrodb.org/thumbnail.png",
-        "download": "https://github.com/TheIntroDB/stremio-enhanced-plugin/releases/download/v0.1.2/tidb.plugin.js"
+        "download": "https://github.com/TheIntroDB/stremio-enhanced-plugin/releases/download/0.1.2/tidb.plugin.js"
       },
       {
         "name": "Stremio Addon Manager",

--- a/registry.json
+++ b/registry.json
@@ -12,10 +12,10 @@
         "name": "TheIntroDB",
         "author": "TheIntroDB",
         "description": "Skip intros, recaps, credits, and previews in TV shows and movies in Stremio Enhanced using TheIntroDB API",
-        "version": "0.1.1",
+        "version": "0.1.2",
         "repo": "https://github.com/TheIntroDB/stremio-enhanced-plugin",
         "preview": "https://theintrodb.org/thumbnail.png",
-        "download": "https://github.com/TheIntroDB/stremio-enhanced-plugin/releases/download/v0.1.1/tidb.plugin.js"
+        "download": "https://github.com/TheIntroDB/stremio-enhanced-plugin/releases/download/v0.1.2/tidb.plugin.js"
       },
       {
         "name": "Stremio Addon Manager",


### PR DESCRIPTION
This PR adds TheIntroDB to the registry

TheIntroDB is a free, open access API for intros, recaps, credits, and previews in TV shows and movies.

The plugin adds Skip buttons for intro, recap, credits, and preview segments, as well as visual indicators on the timeline.

<img width="1500" height="878" alt="Screenshot 2026-03-24 at 7 31 47 PM" src="https://github.com/user-attachments/assets/69dedae9-4e2b-4bd9-8697-43022119f11e" />
