### PR TITLE
Added a Expand Stream Titles plugin like in Stremio kai

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -122,15 +122,12 @@
       "download": "https://github.com/JZOnTheGit/stream-quality-picker/releases/download/v1.4.0/stream-quality-picker.plugin.js"
     },
     {
-      "name": "Expand Stream Titles",
+      "name": "ExpandStreamTitles",
+      "description": "Removes text truncation on stream links, allowing full release titles to display.",
+      "version": "1.0.1",
       "author": "Enkvaros",
-      "description": "Fixes truncated stream title names in the streams sidebar by wrapping text.",
-      "version": "1.0.0",
-      "repo": "https://github.com/Enkvaros/stremio-enhanced-stream-titles-fixed",
-      "download": "https://github.com/Enkvaros/stremio-enhanced-stream-titles-fixed/releases/download/V1.0.0/expand-stream-titles.plugin.js"
-    }
-  ],
-  "themes": [
+      "download": "https://github.com/Enkvaros/stremio-enhanced-stream-titles-fixed/releases/download/v1.0.1/expand-stream-titles.plugin.js"
+    },
     {
       "name": "Modern Glass",
       "author": "Fxy",

--- a/registry.json
+++ b/registry.json
@@ -123,11 +123,11 @@
     },
     {
       "name": "Expand Stream Titles",
-      "author": "You",
+      "author": "Enkvaros",
       "description": "Fixes truncated stream title names in the streams sidebar by wrapping text.",
       "version": "1.0.0",
-      "repo": "https://github.com/REVENGE977/stremio-enhanced-registry",
-      "download": "https://gist.githubusercontent.com/Enkvaros/43f26fde62795e169f7e47377a58e5c1/raw/2660a409d037fd8776be43baa07767b89b42ed7f/gistfile1.txt"
+      "repo": "https://github.com/Enkvaros/stremio-enhanced-stream-titles-fixed",
+      "download": "https://github.com/Enkvaros/stremio-enhanced-stream-titles-fixed/releases/download/V1.0.0/expand-stream-titles.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -120,6 +120,14 @@
       "version": "1.4.0",
       "repo": "https://github.com/JZOnTheGit/stream-quality-picker",
       "download": "https://github.com/JZOnTheGit/stream-quality-picker/releases/download/v1.4.0/stream-quality-picker.plugin.js"
+    },
+    {
+      "name": "Expand Stream Titles",
+      "author": "You",
+      "description": "Fixes truncated stream title names in the streams sidebar by wrapping text.",
+      "version": "1.0.0",
+      "repo": "https://github.com/REVENGE977/stremio-enhanced-registry",
+      "download": "https://gist.githubusercontent.com/Enkvaros/43f26fde62795e169f7e47377a58e5c1/raw/2660a409d037fd8776be43baa07767b89b42ed7f/gistfile1.txt"
     }
   ],
   "themes": [


### PR DESCRIPTION
i want this as a fix for the "source streams has a long name and not showing entirety of text and not wrapping either"
i am not a programmer or anything this made entirely with GEMINI AI its a short thing if its alright you can check for issues idk
if ai usage not alright i just wanted to add this fix for myself and can't figure out how so here i am