### PR TITLE
Add Library Folders plugin

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -125,10 +125,10 @@
       "name": "Library Folders",
       "author": "M-1u",
       "description": "Organize your Library into folders and subfolders — right-click or drag an item to file it away, rubber-band multi-select, and bulk actions (mark all watched/unwatched, remove all). 100% local, nothing is synced.",
-      "version": "1.3.0",
+      "version": "1.4.1",
       "repo": "https://github.com/M-1u/stremio-library-folders",
       "preview": "https://raw.githubusercontent.com/M-1u/stremio-library-folders/main/screenshots/folders-grid.png",
-      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.3.0/library-folders.plugin.js"
+      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.4.1/library-folders.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -120,6 +120,15 @@
       "version": "1.4.0",
       "repo": "https://github.com/JZOnTheGit/stream-quality-picker",
       "download": "https://github.com/JZOnTheGit/stream-quality-picker/releases/download/v1.4.0/stream-quality-picker.plugin.js"
+    },
+    {
+      "name": "Library Folders",
+      "author": "M-1u",
+      "description": "Organize your Library into folders and subfolders — right-click or drag an item to file it away, rubber-band multi-select, and bulk actions (mark all watched/unwatched, remove all). 100% local, nothing is synced.",
+      "version": "1.2.0",
+      "repo": "https://github.com/M-1u/stremio-library-folders",
+      "preview": "https://raw.githubusercontent.com/M-1u/stremio-library-folders/main/screenshots/folders-grid.png",
+      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.2.0/library-folders.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -125,10 +125,10 @@
       "name": "Library Folders",
       "author": "M-1u",
       "description": "Organize your Library into folders and subfolders — right-click or drag an item to file it away, rubber-band multi-select, and bulk actions (mark all watched/unwatched, remove all). 100% local, nothing is synced.",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "repo": "https://github.com/M-1u/stremio-library-folders",
       "preview": "https://raw.githubusercontent.com/M-1u/stremio-library-folders/main/screenshots/folders-grid.png",
-      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.4.5/library-folders.plugin.js"
+      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.4.6/library-folders.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -125,10 +125,10 @@
       "name": "Library Folders",
       "author": "M-1u",
       "description": "Organize your Library into folders and subfolders — right-click or drag an item to file it away, rubber-band multi-select, and bulk actions (mark all watched/unwatched, remove all). 100% local, nothing is synced.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "repo": "https://github.com/M-1u/stremio-library-folders",
       "preview": "https://raw.githubusercontent.com/M-1u/stremio-library-folders/main/screenshots/folders-grid.png",
-      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.2.0/library-folders.plugin.js"
+      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.3.0/library-folders.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -125,10 +125,10 @@
       "name": "Library Folders",
       "author": "M-1u",
       "description": "Organize your Library into folders and subfolders — right-click or drag an item to file it away, rubber-band multi-select, and bulk actions (mark all watched/unwatched, remove all). 100% local, nothing is synced.",
-      "version": "1.4.6",
+      "version": "1.6.0",
       "repo": "https://github.com/M-1u/stremio-library-folders",
       "preview": "https://raw.githubusercontent.com/M-1u/stremio-library-folders/main/screenshots/folders-grid.png",
-      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.4.6/library-folders.plugin.js"
+      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.6.0/library-folders.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -125,10 +125,10 @@
       "name": "Library Folders",
       "author": "M-1u",
       "description": "Organize your Library into folders and subfolders — right-click or drag an item to file it away, rubber-band multi-select, and bulk actions (mark all watched/unwatched, remove all). 100% local, nothing is synced.",
-      "version": "1.4.1",
+      "version": "1.4.5",
       "repo": "https://github.com/M-1u/stremio-library-folders",
       "preview": "https://raw.githubusercontent.com/M-1u/stremio-library-folders/main/screenshots/folders-grid.png",
-      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.4.1/library-folders.plugin.js"
+      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.4.5/library-folders.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -125,10 +125,10 @@
       "name": "Library Folders",
       "author": "M-1u",
       "description": "Organize your Library into folders and subfolders — right-click or drag an item to file it away, rubber-band multi-select, and bulk actions (mark all watched/unwatched, remove all). 100% local, nothing is synced.",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "repo": "https://github.com/M-1u/stremio-library-folders",
       "preview": "https://raw.githubusercontent.com/M-1u/stremio-library-folders/main/screenshots/folders-grid.png",
-      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.6.0/library-folders.plugin.js"
+      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.6.1/library-folders.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -125,10 +125,10 @@
       "name": "Library Folders",
       "author": "M-1u",
       "description": "Organize your Library into folders and subfolders — right-click or drag an item to file it away, rubber-band multi-select, and bulk actions (mark all watched/unwatched, remove all). 100% local, nothing is synced.",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "repo": "https://github.com/M-1u/stremio-library-folders",
       "preview": "https://raw.githubusercontent.com/M-1u/stremio-library-folders/main/screenshots/folders-grid.png",
-      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.6.1/library-folders.plugin.js"
+      "download": "https://github.com/M-1u/stremio-library-folders/releases/download/v1.6.2/library-folders.plugin.js"
     }
   ],
   "themes": [


### PR DESCRIPTION
## Plugin

**Library Folders** — organize your Stremio Library into folders and subfolders.

- Right-click or drag an item onto a folder to file it away, drag onto breadcrumb entries too.
- Desktop-style rubber-band multi-select (click-drag on empty space, Ctrl/Cmd-click to toggle), drag the whole group at once.
- Rename/delete folders (deleting never touches your library, items just become unfiled).
- Bulk actions: mark all watched/unwatched, remove all from Library, scoped to the current folder view (including root/unfiled).
- 100% local storage (`localStorage`), nothing is synced to your account.

Repo: https://github.com/M-1u/stremio-library-folders
Release/download used in the registry entry: https://github.com/M-1u/stremio-library-folders/releases/tag/v1.2.0

## Checklist
- [x] Metadata header present at the top of the plugin file
- [x] Code is clear/readable, not obfuscated
- [x] `download` field points to a specific, immutable release version (not a `main`/latest link)
- [x] Follows the existing `registry.json` structure