### PR TITLE
Add Discover Watched Filter plugin

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -120,6 +120,15 @@
       "version": "1.4.0",
       "repo": "https://github.com/JZOnTheGit/stream-quality-picker",
       "download": "https://github.com/JZOnTheGit/stream-quality-picker/releases/download/v1.4.0/stream-quality-picker.plugin.js"
+    },
+    {
+      "name": "Discover Watched Filter",
+      "author": "M-1u",
+      "description": "Adds a button to the Discover page to hide watched items, show only watched items, or show everything. Automatically keeps loading more pages when the current one is fully filtered out. 100% local.",
+      "version": "1.2.0",
+      "repo": "https://github.com/M-1u/stremio-discover-watched-filter",
+      "preview": "https://raw.githubusercontent.com/M-1u/stremio-discover-watched-filter/main/screenshots/hiding-watched.png",
+      "download": "https://github.com/M-1u/stremio-discover-watched-filter/releases/download/v1.2.0/discover-watched-filter.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -125,10 +125,10 @@
       "name": "Discover Watched Filter",
       "author": "M-1u",
       "description": "Adds a button to the Discover page to hide watched items, show only watched items, or show everything. Automatically keeps loading more pages when the current one is fully filtered out. 100% local.",
-      "version": "1.2.9",
+      "version": "1.3.0",
       "repo": "https://github.com/M-1u/stremio-discover-watched-filter",
       "preview": "https://raw.githubusercontent.com/M-1u/stremio-discover-watched-filter/main/screenshots/hiding-watched.png",
-      "download": "https://github.com/M-1u/stremio-discover-watched-filter/releases/download/v1.2.9/discover-watched-filter.plugin.js"
+      "download": "https://github.com/M-1u/stremio-discover-watched-filter/releases/download/v1.3.0/discover-watched-filter.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -125,10 +125,10 @@
       "name": "Discover Watched Filter",
       "author": "M-1u",
       "description": "Adds a button to the Discover page to hide watched items, show only watched items, or show everything. Automatically keeps loading more pages when the current one is fully filtered out. 100% local.",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "repo": "https://github.com/M-1u/stremio-discover-watched-filter",
       "preview": "https://raw.githubusercontent.com/M-1u/stremio-discover-watched-filter/main/screenshots/hiding-watched.png",
-      "download": "https://github.com/M-1u/stremio-discover-watched-filter/releases/download/v1.2.0/discover-watched-filter.plugin.js"
+      "download": "https://github.com/M-1u/stremio-discover-watched-filter/releases/download/v1.2.2/discover-watched-filter.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -125,10 +125,10 @@
       "name": "Discover Watched Filter",
       "author": "M-1u",
       "description": "Adds a button to the Discover page to hide watched items, show only watched items, or show everything. Automatically keeps loading more pages when the current one is fully filtered out. 100% local.",
-      "version": "1.2.2",
+      "version": "1.2.8",
       "repo": "https://github.com/M-1u/stremio-discover-watched-filter",
       "preview": "https://raw.githubusercontent.com/M-1u/stremio-discover-watched-filter/main/screenshots/hiding-watched.png",
-      "download": "https://github.com/M-1u/stremio-discover-watched-filter/releases/download/v1.2.2/discover-watched-filter.plugin.js"
+      "download": "https://github.com/M-1u/stremio-discover-watched-filter/releases/download/v1.2.8/discover-watched-filter.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -125,10 +125,10 @@
       "name": "Discover Watched Filter",
       "author": "M-1u",
       "description": "Adds a button to the Discover page to hide watched items, show only watched items, or show everything. Automatically keeps loading more pages when the current one is fully filtered out. 100% local.",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "repo": "https://github.com/M-1u/stremio-discover-watched-filter",
       "preview": "https://raw.githubusercontent.com/M-1u/stremio-discover-watched-filter/main/screenshots/hiding-watched.png",
-      "download": "https://github.com/M-1u/stremio-discover-watched-filter/releases/download/v1.2.8/discover-watched-filter.plugin.js"
+      "download": "https://github.com/M-1u/stremio-discover-watched-filter/releases/download/v1.2.9/discover-watched-filter.plugin.js"
     }
   ],
   "themes": [

--- a/registry.json
+++ b/registry.json
@@ -125,10 +125,10 @@
       "name": "Discover Watched Filter",
       "author": "M-1u",
       "description": "Adds a button to the Discover page to hide watched items, show only watched items, or show everything. Automatically keeps loading more pages when the current one is fully filtered out. 100% local.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "repo": "https://github.com/M-1u/stremio-discover-watched-filter",
       "preview": "https://raw.githubusercontent.com/M-1u/stremio-discover-watched-filter/main/screenshots/hiding-watched.png",
-      "download": "https://github.com/M-1u/stremio-discover-watched-filter/releases/download/v1.3.0/discover-watched-filter.plugin.js"
+      "download": "https://github.com/M-1u/stremio-discover-watched-filter/releases/download/v1.3.1/discover-watched-filter.plugin.js"
     }
   ],
   "themes": [


### PR DESCRIPTION
## Plugin

**Discover Watched Filter** — adds a button on the Discover page to hide watched items, show only watched items, or show everything.

- Cycles between three states, choice remembered across sessions.
- If the current page ends up fully filtered out, the plugin automatically requests more pages via Stremio's own "load next page" action, so the grid doesn't just stay blank.
- Best-effort cooperation with the Enhanced Titlebar plugin: hidden items are marked so it skips enriching them.
- 100% local storage (`localStorage`), nothing is synced to your account.

Repo: https://github.com/M-1u/stremio-discover-watched-filter
Release/download used in the registry entry: https://github.com/M-1u/stremio-discover-watched-filter/releases/tag/v1.2.0

## Checklist
- [x] Metadata header present at the top of the plugin file
- [x] Code is clear/readable, not obfuscated
- [x] `download` field points to a specific, immutable release version (not a `main`/latest link)
- [x] Follows the existing `registry.json` structure