### PR TITLE
Add plugin: AniListSync (AniList auto-scrobbler)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -120,6 +120,14 @@
       "version": "1.4.0",
       "repo": "https://github.com/JZOnTheGit/stream-quality-picker",
       "download": "https://github.com/JZOnTheGit/stream-quality-picker/releases/download/v1.4.0/stream-quality-picker.plugin.js"
+    },
+    {
+      "name": "Anilist Sync",
+      "author": "GefyDev",
+      "description": "Automated anime tracking plugin for Stremio Enhanced that seamlessly synchronizes your watched anime episodes with your AniList profile in real-time.",
+      "version": "1.0.0",
+      "repo": "https://github.com/gefydev/anilist-plugin-stremio",
+      "download": "https://github.com/gefydev/anilist-plugin-stremio/releases/download/v1.0.0/AniListSync.plugin.js"
     }
   ],
   "themes": [


### PR DESCRIPTION
### 🚀 Description

Closes REVENGE977/stremio-enhanced#122 (requested by @theloneraven)

This PR submits **AniListSync** to the Stremio Enhanced Community Plugin Registry. 

**AniListSync** is a plugin that tracks anime watched in Stremio (via Kitsu catalog) and automatically syncs episode progress to [AniList](https://anilist.co) in real-time.

---

### ✨ Features & Implementation

- **⚡ Automatic Scrobbling:** Updates AniList watched episode count once the user crosses the playback threshold (80% default, configurable from 50% to 90%).
- **🎯 Multi-tier ID Resolution:**
  1. Internal local mapping cache (`localStorage`).
  2. Resolves Kitsu Anime ID to MyAnimeList (MAL) external mappings via Kitsu API.
  3. Direct MAL ID matching on AniList GraphQL API (exact match).
  4. Fallback fuzzy search by title.
- **🙋 First Episode Confirmation:** Prompts with a native dialog asking if the user wants to add newly started anime to their list.
- **🏆 Auto-Completion:** Automatically marks the anime as `COMPLETED` when the user finishes the last episode.
- **⚙️ Native Settings Modal:** Full integration with `StremioEnhancedAPI.registerSettings` and `onSettingsSaved`, featuring real-time token validation and account status display.
- **🛡️ Rate-Limit Safe:** Respects AniList's 90 req/min limits with debounce and exponential retry backoff.

---

### 📦 Plugin Details

- **Plugin Name:** `AniListSync`
- **Author:** [GefyDev](https://github.com/GefyDev) (`hi@gefy.dev`)
- **Repository:** https://github.com/GefyDev/anilist-plugin-stremio
- **Latest Release Download:** `https://github.com/GefyDev/anilist-plugin-stremio/releases/latest/download/AniListSync.plugin.js`
- **License:** MIT

---

### 🧪 Verification & Testing
- Tested end-to-end against live AniList GraphQL endpoints with verified OAuth token.
- Tested DOM safety (strict containment in settings modal without affecting search bars or player UI).
- Tested compatibility with Stremio Enhanced plugin lifecycle and settings APIs.
